### PR TITLE
VM_MAX_READAHEAD set to 512

### DIFF
--- a/kernel/include/linux/mm.h
+++ b/kernel/include/linux/mm.h
@@ -1427,7 +1427,7 @@ int write_one_page(struct page *page, int wait);
 void task_dirty_inc(struct task_struct *tsk);
 
 /* readahead.c */
-#define VM_MAX_READAHEAD	128	/* kbytes */
+#define VM_MAX_READAHEAD	512	/* kbytes */
 #define VM_MIN_READAHEAD	16	/* kbytes (includes current page) */
 
 int force_page_cache_readahead(struct address_space *mapping, struct file *filp,


### PR DESCRIPTION
Tuning read-ahead can improve read performance.