### PR TITLE
Tweak VM Dirty Ratios

### DIFF
--- a/kernel/mm/page-writeback.c
+++ b/kernel/mm/page-writeback.c
@@ -65,7 +65,7 @@ static long ratelimit_pages = 32;
 /*
  * Start background writeback (via writeback threads) at this percentage
  */
-int dirty_background_ratio = 1;
+int dirty_background_ratio = 80;
 
 /*
  * dirty_background_bytes starts at 0 (disabled) so that it is a function of
@@ -82,7 +82,7 @@ int vm_highmem_is_dirtyable;
 /*
  * The generator of dirty data starts writeback at this percentage
  */
-int vm_dirty_ratio = 20;
+int vm_dirty_ratio = 90;
 
 /*
  * vm_dirty_bytes starts at 0 (disabled) so that it is a function of
@@ -100,7 +100,7 @@ EXPORT_SYMBOL_GPL(dirty_writeback_interval);
 /*
  * The longest time for which data is allowed to remain dirty
  */
-unsigned int dirty_expire_interval = 30 * 100; /* centiseconds */
+unsigned int dirty_expire_interval = 10 * 100; /* centiseconds */
 
 /*
  * Flag that makes the machine dump writes/reads and block dirtyings.


### PR DESCRIPTION
Dirty Ratio and Dirty Background Ratio control how often the kernel writes data to disk.