### PR TITLE
Enabled ARCH_POWER

### DIFF
--- a/kernel/kernel/sched/features.h
+++ b/kernel/kernel/sched/features.h
@@ -42,7 +42,7 @@ SCHED_FEAT(CACHE_HOT_BUDDY, true)
 /*
  * Use arch dependent cpu power functions
  */
-SCHED_FEAT(ARCH_POWER, false)
+SCHED_FEAT(ARCH_POWER, true)
 
 SCHED_FEAT(HRTICK, false)
 SCHED_FEAT(DOUBLE_TICK, false)


### PR DESCRIPTION
Heteregeneous ARM platform uses arch_scale_freq_power function
to reflect the relative capacity of each core